### PR TITLE
Fix query optimizer dataframe handling

### DIFF
--- a/modules/GUI/query_optimizer_tab.py
+++ b/modules/GUI/query_optimizer_tab.py
@@ -55,10 +55,14 @@ class QueryOptimizerTab(QWidget):
         df_combined = combine_queries(scopus_path, wos_path if wos_path else None)
         df_cleaned = clean_data(df_combined)
 
+        # Inicializar df_filtered con el dataframe limpiado
+        df_filtered = df_cleaned
+
+        # Si se proporciona un keyword, filtrar
         if keyword:
             df_filtered = filter_by_keyword(df_cleaned, keyword)
 
-        # Guardar y generar resultados
+        # Guardar y generar resultados asegurando que se pase un DataFrame válido
         save_data(df_filtered, "filtered_results.csv")
 
         self.update_log("Query Optimizer completed.")


### PR DESCRIPTION
## Summary
- avoid use of an unassigned dataframe when no keyword filter is provided

## Testing
- `python -m py_compile modules/GUI/query_optimizer_tab.py`
- `python -m py_compile modules/download/query_optimizer.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840d097c2f4832793d8b8906ee52495